### PR TITLE
Skip non-ICS files when loading from a directory

### DIFF
--- a/calcure/loaders.py
+++ b/calcure/loaders.py
@@ -277,7 +277,12 @@ class LoaderICS:
             for filename in files:
                 # Get the full path to the file
                 file_path = os.path.join(root, filename)
-                ics_files.append(self.read_file(file_path))
+
+                # `path` may contain files with metadata, e.g. `color` and
+                # `displayname`. For now, exclude those while loading.
+                if file_path.endswith('.ics'):
+                    ics_files.append(self.read_file(file_path))
+
         return ics_files
 
 


### PR DESCRIPTION
Directories containing ICS files may also contain metadata files. For example, `vdirsyncer` used with the Vdir format creates files such as `color` and `displayname`, in the same directory as all other ICS files ([see documentation](https://vdirsyncer.pimutils.org/en/stable/vdir.html?highlight=metadata#metadata)). However, metadata files should be handled separately, and should not be loaded as ICS files.