### PR TITLE
Slovenian translations added

### DIFF
--- a/calcure/__main__.py
+++ b/calcure/__main__.py
@@ -54,6 +54,8 @@ elif cf.LANG == "es":
     from calcure.translations.es import *
 elif cf.LANG == "hu":
     from calcure.translations.hu import *
+elif cf.LANG == "si":
+    from calcure.translations.si import *
 else:
     from calcure.translations.en import *
 
@@ -711,7 +713,7 @@ class WeekNumberView(View):
     def render(self):
         """Render this view on the screen"""
         y_cell = (self.screen.y_max - 3) // 6
-        
+
         for row, week_num in enumerate(self.week_numbers):
             # Position week number in the vertical middle of the cell
             y_pos = 2 + row * y_cell + (y_cell // 2)
@@ -873,7 +875,7 @@ class MonthlyScreenView(View):
             week_numbers = []
             week_column_width = 0
             calendar_start_x = 0
-        
+
         y_cell = (self.screen.y_max - 3) // 6
         x_cell = (self.screen.x_max - week_column_width) // 7
 

--- a/calcure/controls.py
+++ b/calcure/controls.py
@@ -30,6 +30,8 @@ elif cf.LANG == "sk":
     from calcure.translations.sk import *
 elif cf.LANG == "es":
     from calcure.translations.es import *
+elif cf.LANG == "si":
+    from calcure.translations.si import *
 else:
     from calcure.translations.en import *
 

--- a/calcure/translations/si.py
+++ b/calcure/translations/si.py
@@ -1,0 +1,114 @@
+"""Slovene translations of the program interface"""
+
+MSG_WELCOME_1 = "Dobrodošel/-a v Calcure"
+MSG_WELCOME_2 = "Calcure je koledar in upravitelj opravil v terminalu!"
+MSG_WELCOME_3 = "Datoteke s konfiguracijo in podatki so bile ustvarjene v:"
+MSG_WELCOME_4 = "Za podporo, sodelovanje in dodatne informacije obišči:"
+MSG_WELCOME_5 = "Pritisni ? za prikaz ukazov ali poljubno drugo tipko za nadaljevanje."
+
+TITLE_KEYS_GENERAL = "SPLOŠNI UKAZI"
+TITLE_KEYS_CALENDAR = "UPRAVLJANJE S KOLEDARJEM"
+TITLE_KEYS_JOURNAL  = "UPRAVLJANJE Z DNEVNIKOM"
+
+KEYS_GENERAL = {
+        " Presl.": "Preklopi med koledarjem in dnevnikom",
+        "   /   ": "Vklopi/izklopi razdeljeni zaslon",
+        "   *   ": "Globalno vklopi/izklopi zasebnost",
+        "   ?   ": "Prikaži/skrij pomoč",
+        "   Q   ": "Osveži podatke",
+        "   q   ": "Zapri program",
+        }
+
+KEYS_CALENDAR = {
+        "  a(A) ": "Dodaj (ponavljajoč se) dogodek",
+        "   n   ": "Naslednji mesec (dan)",
+        "   p   ": "Prejšnji mesec (dan)",
+        "   x   ": "Odstrani dogodek",
+        "   r   ": "Preimenuj dogodek",
+        "  m(M) ": "Premakni dogodek (v tem mescu)",
+        "  g(G) ": "Pojdi na določen dan (v tem mescu)",
+        "   v   ": "Preklopi med dnevnim in mesečnim prikazom",
+        "   w   ": "Prikaži/skrij številke tednov",
+        "   h   ": "Označi/odznači dogodek kot visokoprioriteten",
+        "   l   ": "Označi/odznači dogodek kot nizkoprioriteten",
+        "   d   ": "Označi/odznači dogodek kot končan",
+        "   .   ": "Vklopi/izklopi zasebnost za dogodek",
+        "   C   ": "Uvozi dogodke iz programa Calcurse",
+        "   R   ": "Vrni se na trenutni mesec (dan)",
+        }
+
+KEYS_TODO = {
+        "  a(A) ": "Dodaj novo (pod)opravilo",
+        "  h(H) ": "Označi/odznači eno (vsa) opravilo kot visokoprioritetno",
+        "  l(L) ": "Označi/odznači eno (vsa) opravilo kot nizkoprioritetno",
+        "  d(D) ": "Označi/odznači eno (vsa) opravilo kot opravljeno",
+        "  u(U) ": "Odznači eno (vsa) opravilo",
+        "  x(X) ": "Odstrani eno (vsa) opravilo (z vsemi podopravili)",
+        "  t(T) ": "Poženi/zaustavi (odstrani) uro za opravilo",
+        "   r   ": "Preimenuj opravilo",
+        "   s   ": "Spremeni opravilo v podopravilo ali obratno",
+        "   .   ": "Vklopi/izklopi zasebnost za opravilo",
+        "  f(F) ": "Spremeni (odstrani) rok za opravilo",
+        "   m   ": "Premakni opravilo",
+        "   C   ": "Uvozi opravila iz programa Calcurse",
+        }
+
+MSG_NAME          = "CALCURE"
+MSG_VIM           = "Delujejo tudi puščice in Vimovi ukazi (j, k, ZZ, ZQ)!"
+MSG_INFO          = "Več informacij najdeš na:"
+MSG_SITE          = "https://anufrievroman.gitbook.io/calcure"
+MSG_EXIT          = "Res želiš zapreti program? (y/n) "
+
+MSG_EVENT_HIGH    = "Označi/odznači kot visokoprioriteten dogodek s številko: "
+MSG_EVENT_LOW     = "Označi/odznači kot nizkoprioriteten dogodek s številko: "
+MSG_EVENT_DONE    = "Označi/odznači kot končan dogodek s številko: "
+MSG_EVENT_RESET   = "Ponastavi stanje za dogodek s številko: "
+MSG_EVENT_DEL     = "Odstrani dogodek s številko: "
+MSG_EVENT_REN     = "Preimenuj dogodek s številko: "
+MSG_NEW_TITLE     = "Vnesi novi naslov: "
+MSG_EVENT_MV      = "Premakni dogodek s številko: "
+MSG_EVENT_MV_TO   = "Premakni dogodek na (LLLL/MM/DD): "
+MSG_EVENT_MV_TO_D = "Premakni dogodek na: "
+MSG_EVENT_DATE    = "Vnesi datum: "
+MSG_EVENT_TITLE   = "Vnesi naslov: "
+MSG_EVENT_REP     = "Število ponovitev: "
+MSG_EVENT_FR      = "Ponavljaj dogodek dnevno (d), tedensko (w), dvotedensko (b), mesečno (m) ali letno (y)? "
+MSG_EVENT_IMP     = "Uvozi dogodke iz programa Calcurse? (y/n)"
+MSG_EVENT_PRIVACY = "Vklopi/izklopi zasebnost za dogodek s številko: "
+MSG_TM_ADD        = "Poženi/zaustavi uro za opravilo s številko: "
+MSG_TM_RESET      = "Odstrani uro za opravilo s številko: "
+MSG_TS_HIGH       = "Označi/odznači kot visokoprioritetno opravilo s številko: "
+MSG_TS_LOW        = "Označi/odznači kot nizkoprioritetno opravilo s številko: "
+MSG_TS_RES        = "Ponastavi stanje za opravilo s številko: "
+MSG_TS_DONE       = "Označi/odznači kot opravljeno opravilo s številko: "
+MSG_TS_DEL        = "Odstrani opravilo s številko: "
+MSG_TS_DEL_ALL    = "Res želiš odstraniti vsa opravila? (y/n)"
+MSG_TS_EDT_ALL    = "Potrjuješ to odločitev? (y/n)"
+MSG_TS_MOVE       = "Premakni opravilo s številko: "
+MSG_TS_MOVE_TO    = "Premakni opravilo na mesto s številko: "
+MSG_TS_EDIT       = "Uredi opravilo s številko: "
+MSG_TS_TOG        = "Spremeni opravilo/podopravilo s številko: "
+MSG_TS_SUB        = "Dodaj podopravilo za opravilo s številko: "
+MSG_TS_TITLE      = "Vnesi podopravilo: "
+MSG_TS_IM         = "Uvozi opravila iz programa Calcurse? (y/n)"
+MSG_TS_TW         = "Uvozi opravila iz programa Taskwarrior? (y/n)"
+MSG_TS_NOTHING    = "Ni načrtov ..."
+MSG_TS_PRIVACY    = "Vklopi/izklopi zasebnost za opravilo s številko: "
+MSG_TS_DEAD_ADD   = "Dodaj rok za opravilo s številko: "
+MSG_TS_DEAD_DEL   = "Odstrani rok za opravilo s številko: "
+MSG_TS_DEAD_DATE  = "Dodaj rok (LLLL/MM/DD): "
+MSG_WEATHER       = "Vreme se nalaga ..."
+MSG_ERRORS        = "Prišlo je do napak. Poglej info.log v svoji konfiguracijski mapi."
+MSG_INPUT         = "Neveljaven vnos."
+MSG_GOTO          = "Pojdi na datum (LLLL/MM/DD): "
+MSG_GOTO_D        = "Pojdi na datum: "
+
+CALENDAR_HINT     = "Presledek · Preklopi na dnevnik   a · Dodaj dogodek  n/p · Zamenjaj mesec   ? · Vsi ukazi"
+CALENDAR_HINT_D   = "Presledek · Preklopi na dnevnik   a · Dodaj dogodek  n/p · Zamenjaj dan   ? · Vsi ukazi"
+JOURNAL_HINT      = "Presledek · Preklopi na koledar   a · Dodaj opravilo   d · Opravljeno   i · Pomembno   ? · Vsi ukazi"
+
+DAYS = ["PONEDELJEK", "TOREK", "SREDA", "ČETRTEK", "PETEK", "SOBOTA", "NEDELJA"]
+DAYS_PERSIAN = ["SHANBEH", "YEKSHANBEH", "DOSHANBEH", "SESHANBEH", "CHAHARSHANBEH", "PANJSHANBEH", "JOMEH"]
+
+MONTHS = ["JANUAR", "FEBRUAR", "MAREC", "APRIL", "MAJ", "JUNIJ", "JULIJ", "AVGUST", "SEPTEMBER", "OKTOBER", "NOVEMBER", "DECEMBER"]
+MONTHS_PERSIAN = ["FARVARDIN", "ORDIBEHESHT", "KHORDAD", "TIR", "MORDAD", "SHAHRIVAR", "MEHR", "ABAN", "AZAR", "DEY", "BAHMAN", "ESFAND"]


### PR DESCRIPTION
Translations for Slovene (`si`) added.

I suggest [the docs](https://anufrievroman.gitbook.io/calcure/settings) are updated accordingly.