### PR TITLE
Bugs with displaying custom background color fixed

### DIFF
--- a/calcure/__main__.py
+++ b/calcure/__main__.py
@@ -95,12 +95,6 @@ class View:
         self.y = y
         self.x = x
 
-    def fill_background(self):
-        """Fill the screen background with background color"""
-        y_max, x_max = self.stdscr.getmaxyx()
-        for index in range(y_max - 1):
-            self.stdscr.addstr(index, 0, " " * x_max, curses.color_pair(Color.EMPTY.value))
-
     def display_line(self, y, x, text, color, bold=False, underlined=False):
         """Display the line of text respecting the slyling and available space"""
 
@@ -620,6 +614,9 @@ class FooterView(View):
                 hint = CALENDAR_HINT_D
         elif self.screen.state == AppState.JOURNAL:
             hint = JOURNAL_HINT
+        else:
+            # Render empty hint to fill the line with the background color.
+            hint = ""
         self.display_line(self.screen.y_max - 1, 0, hint, Color.HINTS)
 
 
@@ -952,7 +949,6 @@ class WelcomeScreenView(View):
         """Draw the welcome screen"""
         self.calibrate_position()
         self.stdscr.clear()
-        self.fill_background()
 
         if self.x_max < len(MSG_WELCOME_4)+2 or self.y_max < 12:
             self.display_line(0, 0, "Welcome!", Color.ACTIVE_PANE)
@@ -1001,7 +997,6 @@ class HelpScreenView(View):
         if self.x_max < 6 or self.y_max < 3:
             return
         self.stdscr.clear()
-        self.fill_background()
 
         # Left column:
         self.display_line(self.global_shift_y, self.global_shift_x + 1, f"{MSG_NAME} {__version__}",
@@ -1043,6 +1038,7 @@ def main(stdscr) -> None:
     if cf.SHOW_WEATHER:
         threading.Thread(target=weather.load_from_wttr).start()
 
+    stdscr.bkgd(" ", curses.color_pair(Color.DEFAULT.value))
     screen = Screen(stdscr, cf)
 
     # Initialise loaders:
@@ -1092,6 +1088,7 @@ def main(stdscr) -> None:
         screen.state = AppState.WELCOME
     while screen.state == AppState.WELCOME:
         welcome_screen_view.render()
+        footer_view.render()
         control_welcome_screen(stdscr, screen)
 
     # Running different screens depending on the state:
@@ -1102,7 +1099,6 @@ def main(stdscr) -> None:
         # screen should be the preferred default.
         # Note that the loop generally hangs waiting for user input.
         stdscr.clear()
-        app_view.fill_background()
 
         if user_tasks.has_active_timer and screen.state == AppState.JOURNAL:
             # By setting a `halfdelay`, we only wait for user input for the
@@ -1149,6 +1145,7 @@ def main(stdscr) -> None:
         # Help screen:
         elif screen.state == AppState.HELP:
             help_screen_view.render()
+            footer_view.render()
             control_help_screen(stdscr, screen)
 
         else:

--- a/calcure/__main__.py
+++ b/calcure/__main__.py
@@ -614,9 +614,6 @@ class FooterView(View):
                 hint = CALENDAR_HINT_D
         elif self.screen.state == AppState.JOURNAL:
             hint = JOURNAL_HINT
-        else:
-            # Render empty hint to fill the line with the background color.
-            hint = ""
         self.display_line(self.screen.y_max - 1, 0, hint, Color.HINTS)
 
 
@@ -1088,7 +1085,6 @@ def main(stdscr) -> None:
         screen.state = AppState.WELCOME
     while screen.state == AppState.WELCOME:
         welcome_screen_view.render()
-        footer_view.render()
         control_welcome_screen(stdscr, screen)
 
     # Running different screens depending on the state:
@@ -1145,7 +1141,6 @@ def main(stdscr) -> None:
         # Help screen:
         elif screen.state == AppState.HELP:
             help_screen_view.render()
-            footer_view.render()
             control_help_screen(stdscr, screen)
 
         else:

--- a/calcure/colors.py
+++ b/calcure/colors.py
@@ -6,6 +6,7 @@ from enum import Enum, auto
 
 class Color(Enum):
     """Colors read from user config"""
+    DEFAULT = auto()
     DAY_NAMES = auto()
     WEEKENDS = auto()
     HINTS = auto()
@@ -30,7 +31,6 @@ class Color(Enum):
     CALENDAR_HEADER = auto()
     ACTIVE_PANE = auto()
     SEPARATOR = auto()
-    EMPTY = auto()
     CALENDAR_BORDER = auto()
     DEADLINES = auto()
     ICS_CALENDARS0 = auto()
@@ -50,6 +50,7 @@ def initialize_colors(cf):
     """Define all the color pairs"""
     curses.start_color()
     curses.use_default_colors()
+    curses.init_pair(Color.DEFAULT.value, cf.COLOR_FOREGROUND, cf.COLOR_BACKGROUND)
     curses.init_pair(Color.DAY_NAMES.value, cf.COLOR_DAY_NAMES, cf.COLOR_BACKGROUND)
     curses.init_pair(Color.WEEKENDS.value, cf.COLOR_WEEKENDS, cf.COLOR_BACKGROUND)
     curses.init_pair(Color.HINTS.value, cf.COLOR_HINTS, cf.COLOR_BACKGROUND)
@@ -74,7 +75,6 @@ def initialize_colors(cf):
     curses.init_pair(Color.CALENDAR_HEADER.value, cf.COLOR_CALENDAR_HEADER, cf.COLOR_BACKGROUND)
     curses.init_pair(Color.ACTIVE_PANE.value, cf.COLOR_ACTIVE_PANE, cf.COLOR_BACKGROUND)
     curses.init_pair(Color.SEPARATOR.value, cf.COLOR_SEPARATOR, cf.COLOR_BACKGROUND)
-    curses.init_pair(Color.EMPTY.value, cf.COLOR_BACKGROUND, cf.COLOR_BACKGROUND)
     curses.init_pair(Color.CALENDAR_BORDER.value, cf.COLOR_CALENDAR_BORDER, cf.COLOR_BACKGROUND)
     curses.init_pair(Color.DEADLINES.value, cf.COLOR_DEADLINES, cf.COLOR_BACKGROUND)
     # Initialize week numbers with a dim white/grey color

--- a/calcure/configuration.py
+++ b/calcure/configuration.py
@@ -128,6 +128,7 @@ class Config:
                 "color_separator":       "7",
                 "color_calendar_border": "7",
                 "color_ics_calendars":   "2,3,1,7,4,5,2,3,1,7",
+                "color_foreground":      "-1",
                 "color_background":      "-1",
                 }
 
@@ -293,6 +294,7 @@ class Config:
             self.COLOR_TIMER_PAUSED    = int(conf.get("Colors", "color_timer_paused", fallback=7))
             self.COLOR_TIME            = int(conf.get("Colors", "color_time", fallback=7))
             self.COLOR_WEATHER         = int(conf.get("Colors", "color_weather", fallback=2))
+            self.COLOR_FOREGROUND      = int(conf.get("Colors", "color_foreground", fallback=-1))
             self.COLOR_BACKGROUND      = int(conf.get("Colors", "color_background", fallback=-1))
             self.COLOR_CALENDAR_HEADER = int(conf.get("Colors", "color_calendar_header", fallback=4))
             self.COLOR_ACTIVE_PANE     = int(conf.get("Colors", "color_active_pane", fallback=2))

--- a/calcure/dialogues.py
+++ b/calcure/dialogues.py
@@ -37,12 +37,12 @@ def display_question(stdscr, y, x, question, color):
 def clear_line(stdscr, y, x=0):
     """Clear a line from any text"""
     _, x_max = stdscr.getmaxyx()
-    stdscr.addstr(y, x, " " * (x_max - x - 1), curses.color_pair(Color.EMPTY.value))
+    stdscr.addstr(y, x, " " * (x_max - x - 1), curses.color_pair(Color.DEFAULT.value))
 
 
 def input_field(stdscr, y, x, field_length):
     """Input field that gets characters entered by user"""
-    curses.curs_set(1)
+    curses.curs_set(True)
     input_str = ""
     cursor_pos = 0
 
@@ -66,8 +66,6 @@ def input_field(stdscr, y, x, field_length):
             elif cursor_pos < field_length: # Other characters:
                 input_str = input_str[:cursor_pos] + chr(ord(key)) + input_str[cursor_pos:]
                 cursor_pos += 1
-            else:
-                pass
 
         # Various keys:
         else:
@@ -80,9 +78,6 @@ def input_field(stdscr, y, x, field_length):
                 cursor_pos -= 1
             elif key == curses.KEY_RIGHT and cursor_pos < len(input_str):
                 cursor_pos += 1
-            else:
-                pass
-
 
         # Redraw input field:
         stdscr.addstr(y, x, input_str + " ")


### PR DESCRIPTION
Fixes the following bugs:
> If a custom background color was set (so non-transparent background):
> - the footer background in the _welcome_ and _help_ views would remain transparent,
> - background in the cells behind user input would become transparent as text was typed.

---

### Technical note
The `fill_background` method was doing duplicate work, as it was always called right after `clear`, which already fills the background with the defaults (they just had to be set appropriately). I defined a new `Color.DEFAULT` in place of the previous `Color.EMPTY`, and kept the default character `" "`, which both:
- allows the user to configure a custom foreground color (only appears for user-typed text), and
- is actually required for typed text to be visible at all.