### PR TITLE
Bugfix: Black flash on application launch fixed

### DIFF
--- a/calcure/__main__.py
+++ b/calcure/__main__.py
@@ -1104,7 +1104,10 @@ def main(stdscr) -> None:
     if cf.SHOW_WEATHER:
         threading.Thread(target=weather.load_from_wttr).start()
 
+    # Initialise terminal screen:
+    initialize_colors(cf)
     stdscr.bkgd(" ", curses.color_pair(Color.DEFAULT.value))
+    curses.curs_set(False)
     screen = Screen(stdscr, cf)
 
     # Initialise loaders:
@@ -1129,12 +1132,6 @@ def main(stdscr) -> None:
     importer = Importer(user_tasks, user_events, cf)
 
     read_items_from_user_arguments(screen, user_tasks, user_events, task_saver_csv, event_saver_csv)
-
-    # Initialise terminal screen:
-    stdscr = curses.initscr()
-    curses.noecho()
-    curses.curs_set(False)
-    initialize_colors(cf)
 
     # Initialise screen views:
     app_view = View(stdscr, 0, 0)


### PR DESCRIPTION
## Bug description
On launching `calcure`, the entire screen would flash in the black color. This would happen whenever the app was launched, but was only visible if the default terminal color was _not_ black (ANSI 0).

## Fix
The fix was to remove the redundant `curses.initscr` call, which is already handled automatically by `curses.wrapper` ([docs](https://docs.python.org/3/library/curses.html#curses.wrapper)).
I also removed the `noecho` call, as `wrapper` handled that as well.