### PR TITLE
docs: fix README receive typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ On the first run, program will create a `config.ini` file where you can edit par
 
 ### Setting daily reminders
 
-You can try [this project](https://github.com/sponkurtus2/calcxporte_r) to recieve daily reminders of events in your Calcure.
+You can try [this project](https://github.com/sponkurtus2/calcxporte_r) to receive daily reminders of events in your Calcure.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary
- fix a spelling typo in the README daily reminders section

## Validation
- `rg -n 'recieve|receive|daily reminders|calcxporte_r' README.md`\n- `rg -n 'recieve' README.md` (no matches after the change)\n- `git diff --check`\n\nNo runtime tests were run because this is a README prose-only change and does not alter code, commands, configuration, generated output, dependencies, or API behavior.